### PR TITLE
content: remove registration links

### DIFF
--- a/content/de/events/acdh-ch-lecture-10-3.mdx
+++ b/content/de/events/acdh-ch-lecture-10-3.mdx
@@ -18,7 +18,7 @@ Montag, 17. Juni 2024; 17:00 – 18:30
 Dr. Ignaz Seipel-Platz 2, 1010 Vienna
 
 **Registrierung:**\
-Bitte melden Sie sich für die Lecture bis spätestens **Donnerstag, 13. Juni** 2024 [über diesen Link](https://www.oeaw.ac.at/acdh/events/registration/acdh-ch-lecture) an.
+Bitte melden Sie sich für die Lecture bis spätestens **Donnerstag, 13. Juni** 2024 an.
 
 **Vortragssprache:** Englisch
 
@@ -29,8 +29,6 @@ Professor für Künstliche Intelligenz und Geisteswissenschaften an der Universi
 ***(Erforschung des digitalen Menschen mit moderner KI)***
 
 In diesem Vortrag wird vorgestellt, wie wir den digitalen Menschen in Archiven mit neuen digitalen Methoden im Zeitalter des Deep Learning erforschen können. Archive sind seit langem ein zentrales Thema in akademischen Debatten über Wahrheit, Erinnerung, Aufzeichnung und Macht und sind wichtige Orte für sozial- und geisteswissenschaftliche Forschung. Diese Debatten haben sich mit der digitalen Transformation der Archive nur noch beschleunigt. In diesem Vortrag werden neue Methoden und Werkzeuge vorgestellt, mit denen sich Gedächtnis- und Machtverhältnisse in digitalen Archiven verändern lassen, indem marginalisierte, nicht-kanonische Einheiten in digitalen Archiven neu zusammengesetzt werden. Abschließend werde ich die Pläne für mein neues ERC-Stipendium zum Thema Deep Culture vorstellen, das die kritische Analyse zeitgenössischer Deep-Learning-Praktiken mit dem Versuch verbindet, die methodologische Richtung in den digitalen Geisteswissenschaften zu ändern.
-
-**[Bitte melden Sie sich für den Vor-Ort-Vortrag an / registrieren Sie sich für den Online-Vortrag.](https://www.oeaw.ac.at/acdh/events/registration/acdh-ch-lecture)**
 
 <Grid variant="one-four-columns">
 

--- a/content/en/events/acdh-ch-lecture-10-3.mdx
+++ b/content/en/events/acdh-ch-lecture-10-3.mdx
@@ -18,7 +18,7 @@ Austrian Academy of Sciences (OeAW),\
 Dr. Ignaz Seipel-Platz 2, 1010 Vienna
 
 **Registration:**\
-Please register for the lecture until **Thursday, June 13th** 2024 via [this link](https://www.oeaw.ac.at/acdh/events/registration/acdh-ch-lecture).
+Please register for the lecture until **Thursday, June 13th** 2024.
 
 **Tobias Blanke**\
 Professor of Artificial Intelligence ans Humanities at the University of Amsterdam.
@@ -26,8 +26,6 @@ Professor of Artificial Intelligence ans Humanities at the University of Amsterd
 ***Researching the Digital Human with contemporary AI***
 
 This talk will present how we can research the digital human in archives with new digital methodologies in the age of deep learning. Archives have long been a key concern of academic debates about truth, memory, recording and power and are important sites for social sciences and humanities research. These debates have only accelerated with the digital transformation of archives. This talk presents novel methodologies and tools for changing memory and power relations in digital archives through new ways of reassembling marginalised, non-canonical entities in digital archives. I will finish by introducing the plans for my new ERC grant on deep culture, which integrates the critical analysis of contemporary deep learning practices with an attempt to change the methodological direction in the digital humanities.
-
-**[Please RSVP for the onsite-lecture / register for the online lecture.](https://www.oeaw.ac.at/acdh/events/registration/acdh-ch-lecture)**
 
 <Grid variant="one-four-columns">
 


### PR DESCRIPTION
this removes the registration links for acdh lecture 10.3 (which are no longer valid).